### PR TITLE
Create monastic hub UI layout and site pages

### DIFF
--- a/my-app/app/(site)/contribute/page.tsx
+++ b/my-app/app/(site)/contribute/page.tsx
@@ -1,0 +1,147 @@
+import ContributionCard from "@/components/contribution-card";
+import ProductCard from "@/components/product-card";
+import { Card, CardContent } from "@/components/ui/card";
+import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs";
+import { formatDateTime } from "@/lib/utils";
+import { sb } from "@/lib/supabase-server";
+
+export const metadata = {
+  title: "기여 — 후원/구매/참여",
+};
+
+export const revalidate = 1800;
+
+type InstitutionRow = {
+  id: string | number;
+  name: string;
+  slug: string;
+  donation?: { account?: string | null; page_url?: string | null } | null;
+  summary?: string | null;
+};
+
+type ProductRow = {
+  id: string | number;
+  name: string;
+  image_url?: string | null;
+  price?: number | string | null;
+  category?: string | null;
+  unit?: string | null;
+  buy_url?: string | null;
+  description?: string | null;
+};
+
+type EventRow = {
+  id: string | number;
+  title: string;
+  start_at?: string | null;
+  signup_url?: string | null;
+};
+
+export default async function ContributePage() {
+  const client = sb();
+
+  const [institutionsResponse, productsResponse, eventsResponse] = await Promise.all([
+    client.from("institutions").select("id, name, slug, donation, summary").limit(50),
+    client.from("products").select("*").limit(24),
+    client
+      .from("events")
+      .select("*")
+      .order("start_at", { ascending: true })
+      .limit(24),
+  ]);
+
+  if (institutionsResponse.error) {
+    console.error("Failed to load institutions", institutionsResponse.error);
+  }
+  if (productsResponse.error) {
+    console.error("Failed to load products", productsResponse.error);
+  }
+  if (eventsResponse.error) {
+    console.error("Failed to load events", eventsResponse.error);
+  }
+
+  const institutions = (institutionsResponse.data ?? []) as InstitutionRow[];
+  const products = (productsResponse.data ?? []) as ProductRow[];
+  const events = (eventsResponse.data ?? []) as EventRow[];
+
+  return (
+    <Tabs defaultValue="donate" className="space-y-6">
+      <TabsList className="gap-2">
+        <TabsTrigger value="donate">후원</TabsTrigger>
+        <TabsTrigger value="buy">구매</TabsTrigger>
+        <TabsTrigger value="volunteer">참여</TabsTrigger>
+      </TabsList>
+
+      <TabsContent value="donate" className="space-y-4">
+        {institutions.length ? (
+          <div className="grid gap-4 sm:grid-cols-2 lg:grid-cols-3">
+            {institutions.map((institution) => (
+              <ContributionCard key={institution.id} institution={institution} />
+            ))}
+          </div>
+        ) : (
+          <Card>
+            <CardContent className="p-4 text-sm text-muted-foreground">
+              등록된 후원 정보가 없습니다. 새로운 후원 소식이 준비되는 대로 안내해
+              드릴게요.
+            </CardContent>
+          </Card>
+        )}
+      </TabsContent>
+
+      <TabsContent value="buy" className="space-y-4">
+        {products.length ? (
+          <div className="grid gap-4 sm:grid-cols-2 lg:grid-cols-3 xl:grid-cols-4">
+            {products.map((product) => (
+              <ProductCard key={product.id} item={product} />
+            ))}
+          </div>
+        ) : (
+          <Card>
+            <CardContent className="p-4 text-sm text-muted-foreground">
+              아직 소개할 제품이 없습니다. 상품 등록 후 이곳에서 만나보세요.
+            </CardContent>
+          </Card>
+        )}
+      </TabsContent>
+
+      <TabsContent value="volunteer" className="space-y-4">
+        {events.length ? (
+          <ul className="space-y-2 text-sm">
+            {events.map((event) => (
+              <li
+                key={event.id}
+                className="flex items-center justify-between rounded-md border p-3"
+              >
+                <div>
+                  <p className="font-medium">{event.title}</p>
+                  <p className="text-muted-foreground">
+                    {formatDateTime(event.start_at)}
+                  </p>
+                </div>
+                {event.signup_url ? (
+                  <a
+                    href={event.signup_url}
+                    target="_blank"
+                    rel="noopener noreferrer"
+                    className="underline-offset-4 hover:underline"
+                    aria-label={`${event.title} 신청 페이지 (새 창)`}
+                  >
+                    신청하기
+                  </a>
+                ) : null}
+              </li>
+            ))}
+          </ul>
+        ) : (
+          <Card>
+            <CardContent className="p-4 text-sm text-muted-foreground">
+              예정된 봉사나 행사 소식이 없습니다. 새로운 참여 소식이 열리면 빠르게
+              업데이트하겠습니다.
+            </CardContent>
+          </Card>
+        )}
+      </TabsContent>
+    </Tabs>
+  );
+}

--- a/my-app/app/(site)/institutions/[slug]/page.tsx
+++ b/my-app/app/(site)/institutions/[slug]/page.tsx
@@ -1,0 +1,278 @@
+import Link from "next/link";
+import { notFound } from "next/navigation";
+
+import InstitutionHero from "@/components/institution-hero";
+import NaverMap from "@/components/naver-map";
+import ProductCard from "@/components/product-card";
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+import { formatDateTime } from "@/lib/utils";
+import { sb } from "@/lib/supabase-server";
+
+export async function generateMetadata({
+  params,
+}: {
+  params: { slug: string };
+}) {
+  const client = sb();
+  const { data } = await client
+    .from("institutions")
+    .select("name, description")
+    .eq("slug", params.slug)
+    .single();
+
+  if (!data) {
+    return {
+      title: "기관 — 수도원·수녀원",
+    };
+  }
+
+  return {
+    title: `${data.name} — 수도원·수녀원`,
+    description: data.description ?? undefined,
+  };
+}
+
+type InstitutionDetail = {
+  id: string | number;
+  name: string;
+  slug: string;
+  type?: string | null;
+  description?: string | null;
+  address?: string | null;
+  tags?: string[] | null;
+  lat?: number | null;
+  lng?: number | null;
+  donation?: { account?: string | null; page_url?: string | null } | null;
+  phone?: string | null;
+  email?: string | null;
+  website_url?: string | null;
+};
+
+type ProductRow = {
+  id: string | number;
+  name: string;
+  image_url?: string | null;
+  price?: number | string | null;
+  category?: string | null;
+  unit?: string | null;
+  buy_url?: string | null;
+  description?: string | null;
+};
+
+type EventRow = {
+  id: string | number;
+  title: string;
+  start_at?: string | null;
+  signup_url?: string | null;
+};
+
+export default async function InstitutionPage({
+  params,
+}: {
+  params: { slug: string };
+}) {
+  const client = sb();
+  const { data: institution, error } = await client
+    .from("institutions")
+    .select("*")
+    .eq("slug", params.slug)
+    .single();
+
+  if (error || !institution) {
+    notFound();
+  }
+
+  const donation = (institution.donation ?? {}) as {
+    account?: string | null;
+    page_url?: string | null;
+  };
+
+  const [{ data: products }, { data: events }] = await Promise.all([
+    client
+      .from("products")
+      .select("*")
+      .eq("institution_id", institution.id)
+      .limit(12),
+    client
+      .from("events")
+      .select("*")
+      .eq("institution_id", institution.id)
+      .order("start_at", { ascending: true }),
+  ]);
+
+  const typedInstitution = institution as InstitutionDetail;
+  const typedProducts = (products ?? []) as ProductRow[];
+  const typedEvents = (events ?? []) as EventRow[];
+
+  return (
+    <div className="space-y-6">
+      <nav aria-label="브레드크럼" className="text-sm text-muted-foreground">
+        <ol className="flex flex-wrap items-center gap-2">
+          <li>
+            <Link
+              href="/"
+              className="underline-offset-4 hover:underline focus-visible:outline focus-visible:outline-2 focus-visible:outline-primary/60 focus-visible:outline-offset-4"
+            >
+              홈
+            </Link>
+          </li>
+          <li aria-hidden="true">/</li>
+          <li>
+            <Link
+              href="/map"
+              className="underline-offset-4 hover:underline focus-visible:outline focus-visible:outline-2 focus-visible:outline-primary/60 focus-visible:outline-offset-4"
+            >
+              찾기
+            </Link>
+          </li>
+          <li aria-hidden="true">/</li>
+          <li className="font-medium text-foreground">{typedInstitution.name}</li>
+        </ol>
+      </nav>
+
+      <InstitutionHero
+        name={typedInstitution.name}
+        type={typedInstitution.type}
+        description={typedInstitution.description ?? undefined}
+        address={typedInstitution.address ?? undefined}
+        tags={typedInstitution.tags ?? undefined}
+      />
+
+      <Card>
+        <CardHeader>
+          <CardTitle>위치</CardTitle>
+        </CardHeader>
+        <CardContent className="space-y-3">
+          {typedInstitution.lat && typedInstitution.lng ? (
+            <div className="overflow-hidden rounded-2xl border">
+              <NaverMap
+                center={{
+                  lat: typedInstitution.lat,
+                  lng: typedInstitution.lng,
+                }}
+                markers={[
+                  {
+                    lat: typedInstitution.lat,
+                    lng: typedInstitution.lng,
+                    title: typedInstitution.name,
+                    slug: typedInstitution.slug,
+                  },
+                ]}
+              />
+            </div>
+          ) : (
+            <p className="text-sm text-muted-foreground">
+              주소 또는 좌표 정보가 없습니다.
+            </p>
+          )}
+          {typedInstitution.address ? (
+            <p className="text-sm text-muted-foreground">
+              {typedInstitution.address}
+            </p>
+          ) : null}
+        </CardContent>
+      </Card>
+
+      <div className="grid gap-6 md:grid-cols-2">
+        <Card>
+          <CardHeader>
+            <CardTitle>후원</CardTitle>
+          </CardHeader>
+          <CardContent className="space-y-2 text-sm">
+            {donation.account ? (
+              <p>
+                계좌: <span className="font-semibold">{donation.account}</span>
+              </p>
+            ) : (
+              <p className="text-muted-foreground">등록된 후원 계좌가 없습니다.</p>
+            )}
+            {donation.page_url ? (
+              <a
+                href={donation.page_url}
+                target="_blank"
+                rel="noopener noreferrer"
+                className="underline-offset-4 hover:underline"
+                aria-label={`${typedInstitution.name} 후원 페이지 (새 창)`}
+              >
+                후원 페이지 바로가기
+              </a>
+            ) : null}
+          </CardContent>
+        </Card>
+        <Card>
+          <CardHeader>
+            <CardTitle>연락처</CardTitle>
+          </CardHeader>
+          <CardContent className="space-y-2 text-sm">
+            {typedInstitution.phone ? <p>전화: {typedInstitution.phone}</p> : null}
+            {typedInstitution.email ? (
+              <p>
+                이메일: {" "}
+                <a
+                  href={`mailto:${typedInstitution.email}`}
+                  className="underline-offset-4 hover:underline"
+                >
+                  {typedInstitution.email}
+                </a>
+              </p>
+            ) : null}
+            {typedInstitution.website_url ? (
+              <a
+                href={typedInstitution.website_url}
+                target="_blank"
+                rel="noopener noreferrer"
+                className="underline-offset-4 hover:underline"
+                aria-label={`${typedInstitution.name} 공식 홈페이지 (새 창)`}
+              >
+                공식 홈페이지 바로가기
+              </a>
+            ) : null}
+          </CardContent>
+        </Card>
+      </div>
+
+      {typedProducts.length ? (
+        <section className="space-y-3">
+          <h2 className="text-xl font-semibold">제품</h2>
+          <div className="grid gap-4 sm:grid-cols-2 lg:grid-cols-3">
+            {typedProducts.map((product) => (
+              <ProductCard key={product.id} item={product} />
+            ))}
+          </div>
+        </section>
+      ) : null}
+
+      {typedEvents.length ? (
+        <section className="space-y-3">
+          <h2 className="text-xl font-semibold">행사</h2>
+          <ul className="space-y-2 text-sm">
+            {typedEvents.map((event) => (
+              <li
+                key={event.id}
+                className="flex items-center justify-between rounded-md border p-3"
+              >
+                <div>
+                  <p className="font-medium">{event.title}</p>
+                  <p className="text-muted-foreground">
+                    {formatDateTime(event.start_at)}
+                  </p>
+                </div>
+                {event.signup_url ? (
+                  <a
+                    href={event.signup_url}
+                    target="_blank"
+                    rel="noopener noreferrer"
+                    className="underline-offset-4 hover:underline"
+                    aria-label={`${event.title} 신청 페이지 (새 창)`}
+                  >
+                    신청하기
+                  </a>
+                ) : null}
+              </li>
+            ))}
+          </ul>
+        </section>
+      ) : null}
+    </div>
+  );
+}

--- a/my-app/app/(site)/map/page.tsx
+++ b/my-app/app/(site)/map/page.tsx
@@ -1,0 +1,101 @@
+import InstitutionListItem from "@/components/institution-list-item";
+import NaverMap from "@/components/naver-map";
+import SearchFilters from "@/components/filters/search-filters";
+import { Card, CardContent } from "@/components/ui/card";
+import { sb } from "@/lib/supabase-server";
+
+export const revalidate = 3600;
+export const metadata = {
+  title: "찾기 — 수도원·수녀원",
+};
+
+type MapPageProps = {
+  searchParams?: Record<string, string | string[] | undefined>;
+};
+
+type InstitutionRow = {
+  id: string | number;
+  name: string;
+  slug: string;
+  lat: number | null;
+  lng: number | null;
+  type?: string | null;
+  address?: string | null;
+  tags?: string[] | null;
+};
+
+export default async function MapPage({ searchParams }: MapPageProps) {
+  const supabase = sb();
+  const queryParamRaw =
+    typeof searchParams?.q === "string" ? searchParams.q.trim() : "";
+  const queryParam = queryParamRaw
+    .replace(/['"]/g, "")
+    .replace(/[%_,]/g, (char) => (char === "," ? " " : `\\${char}`));
+  const typeParam =
+    typeof searchParams?.type === "string" ? searchParams.type : "";
+
+  let query = supabase
+    .from("institutions")
+    .select("id, name, slug, lat, lng, type, address, tags")
+    .order("name", { ascending: true });
+
+  if (queryParam) {
+    query = query.or(
+      `name.ilike.%${queryParam}%,address.ilike.%${queryParam}%`,
+    );
+  }
+
+  if (typeParam) {
+    query = query.eq("type", typeParam);
+  }
+
+  const { data, error } = await query;
+
+  if (error) {
+    console.error("Failed to fetch institutions", error);
+  }
+
+  const institutions: InstitutionRow[] = data ?? [];
+
+  const markers = institutions
+    .filter(
+      (institution) =>
+        typeof institution.lat === "number" &&
+        typeof institution.lng === "number",
+    )
+    .map((institution) => ({
+      lat: institution.lat as number,
+      lng: institution.lng as number,
+      title: institution.name,
+      slug: institution.slug,
+    }));
+
+  const mapCenter = markers.length
+    ? { lat: markers[0].lat, lng: markers[0].lng }
+    : { lat: 37.5665, lng: 126.978 };
+
+  return (
+    <div className="grid gap-6 lg:grid-cols-12">
+      <div className="space-y-4 lg:col-span-8">
+        <SearchFilters />
+        <div className="overflow-hidden rounded-2xl border shadow-sm">
+          <NaverMap center={mapCenter} markers={markers} />
+        </div>
+      </div>
+      <aside className="space-y-3 lg:col-span-4">
+        {institutions.length ? (
+          institutions.map((institution) => (
+            <InstitutionListItem key={institution.id} item={institution} />
+          ))
+        ) : (
+          <Card>
+            <CardContent className="p-4 text-sm text-muted-foreground">
+              검색 조건에 해당하는 기관이 없습니다. 다른 키워드나 필터를 선택해
+              보세요.
+            </CardContent>
+          </Card>
+        )}
+      </aside>
+    </div>
+  );
+}

--- a/my-app/app/(site)/news/page.tsx
+++ b/my-app/app/(site)/news/page.tsx
@@ -1,0 +1,61 @@
+import NewsCard from "@/components/news-card";
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+import { sb } from "@/lib/supabase-server";
+
+export const metadata = {
+  title: "뉴스 — 활동 소식",
+};
+
+export const revalidate = 1800;
+
+type NewsRow = {
+  id: string | number;
+  title: string;
+  source_url?: string | null;
+  source_name?: string | null;
+  image_url?: string | null;
+  published_at?: string | null;
+  tags?: string[] | null;
+};
+
+export default async function NewsPage() {
+  const client = sb();
+  const { data, error } = await client
+    .from("news")
+    .select("*")
+    .order("published_at", { ascending: false })
+    .limit(24);
+
+  if (error) {
+    console.error("Failed to load news", error);
+  }
+
+  const items = (data ?? []) as NewsRow[];
+
+  return (
+    <div className="space-y-6">
+      <Card>
+        <CardHeader className="pb-2 pt-4">
+          <CardTitle className="text-base">최근 소식</CardTitle>
+        </CardHeader>
+        <CardContent className="text-sm text-muted-foreground">
+          수도원·수녀원의 활동, 봉사 후기, 제품 출시 등을 카드 뉴스로 전달합니다.
+        </CardContent>
+      </Card>
+      {items.length ? (
+        <div className="grid gap-4 sm:grid-cols-2 lg:grid-cols-3 xl:grid-cols-4">
+          {items.map((item) => (
+            <NewsCard key={item.id} item={item} />
+          ))}
+        </div>
+      ) : (
+        <Card>
+          <CardContent className="p-4 text-sm text-muted-foreground">
+            아직 등록된 소식이 없습니다. 업데이트가 준비되면 이곳에서 확인하실 수
+            있습니다.
+          </CardContent>
+        </Card>
+      )}
+    </div>
+  );
+}

--- a/my-app/app/globals.css
+++ b/my-app/app/globals.css
@@ -66,3 +66,12 @@
     @apply bg-background text-foreground;
   }
 }
+
+@layer utilities {
+  .line-clamp-2 {
+    display: -webkit-box;
+    -webkit-line-clamp: 2;
+    -webkit-box-orient: vertical;
+    overflow: hidden;
+  }
+}

--- a/my-app/app/layout.tsx
+++ b/my-app/app/layout.tsx
@@ -1,16 +1,15 @@
 import type { Metadata } from "next";
 import { Geist } from "next/font/google";
-import { ThemeProvider } from "next-themes";
+
+import Footer from "@/components/footer";
+import Header from "@/components/header";
+import { cn } from "@/lib/utils";
+
 import "./globals.css";
 
-const defaultUrl = process.env.VERCEL_URL
-  ? `https://${process.env.VERCEL_URL}`
-  : "http://localhost:3000";
-
 export const metadata: Metadata = {
-  metadataBase: new URL(defaultUrl),
-  title: "Next.js and Supabase Starter Kit",
-  description: "The fastest way to build apps with Next.js and Supabase",
+  title: "수도원·수녀원 허브",
+  description: "한 곳에서 찾고 참여하는 수도원·수녀원 정보",
 };
 
 const geistSans = Geist({
@@ -25,16 +24,18 @@ export default function RootLayout({
   children: React.ReactNode;
 }>) {
   return (
-    <html lang="en" suppressHydrationWarning>
-      <body className={`${geistSans.className} antialiased`}>
-        <ThemeProvider
-          attribute="class"
-          defaultTheme="system"
-          enableSystem
-          disableTransitionOnChange
-        >
-          {children}
-        </ThemeProvider>
+    <html lang="ko">
+      <body
+        className={cn(
+          geistSans.className,
+          "min-h-screen bg-background text-foreground antialiased",
+        )}
+      >
+        <div className="flex min-h-screen flex-col">
+          <Header />
+          <main className="container mx-auto flex-1 px-4 py-6">{children}</main>
+          <Footer />
+        </div>
       </body>
     </html>
   );

--- a/my-app/app/page.tsx
+++ b/my-app/app/page.tsx
@@ -1,51 +1,128 @@
-import { DeployButton } from "@/components/deploy-button";
-import { EnvVarWarning } from "@/components/env-var-warning";
-import { AuthButton } from "@/components/auth-button";
-import { Hero } from "@/components/hero";
-import { ThemeSwitcher } from "@/components/theme-switcher";
-import { ConnectSupabaseSteps } from "@/components/tutorial/connect-supabase-steps";
-import { SignUpUserSteps } from "@/components/tutorial/sign-up-user-steps";
-import { hasEnvVars } from "@/lib/utils";
 import Link from "next/link";
 
-export default function Home() {
-  return (
-    <main className="min-h-screen flex flex-col items-center">
-      <div className="flex-1 w-full flex flex-col gap-20 items-center">
-        <nav className="w-full flex justify-center border-b border-b-foreground/10 h-16">
-          <div className="w-full max-w-5xl flex justify-between items-center p-3 px-5 text-sm">
-            <div className="flex gap-5 items-center font-semibold">
-              <Link href={"/"}>Next.js Supabase Starter</Link>
-              <div className="flex items-center gap-2">
-                <DeployButton />
-              </div>
-            </div>
-            {!hasEnvVars ? <EnvVarWarning /> : <AuthButton />}
-          </div>
-        </nav>
-        <div className="flex-1 flex flex-col gap-20 max-w-5xl p-5">
-          <Hero />
-          <main className="flex-1 flex flex-col gap-6 px-4">
-            <h2 className="font-medium text-xl mb-4">Next steps</h2>
-            {hasEnvVars ? <SignUpUserSteps /> : <ConnectSupabaseSteps />}
-          </main>
-        </div>
+import { Badge } from "@/components/ui/badge";
+import { Button } from "@/components/ui/button";
+import {
+  Card,
+  CardContent,
+  CardHeader,
+  CardTitle,
+} from "@/components/ui/card";
+import { Separator } from "@/components/ui/separator";
 
-        <footer className="w-full flex items-center justify-center border-t mx-auto text-center text-xs gap-8 py-16">
-          <p>
-            Powered by{" "}
-            <a
-              href="https://supabase.com/?utm_source=create-next-app&utm_medium=template&utm_term=nextjs"
-              target="_blank"
-              className="font-bold hover:underline"
-              rel="noreferrer"
-            >
-              Supabase
-            </a>
+export default function HomePage() {
+  return (
+    <div className="space-y-12">
+      <section className="overflow-hidden rounded-3xl border bg-gradient-to-br from-indigo-100 via-white to-emerald-100 px-6 py-12 shadow-sm">
+        <div className="mx-auto max-w-3xl space-y-6 text-center">
+          <Badge variant="secondary" className="bg-white/80 px-3 py-1 text-xs font-medium">
+            Monastic Community Hub
+          </Badge>
+          <div className="space-y-4">
+            <h1 className="text-3xl font-semibold leading-tight sm:text-4xl">
+              전국의 수도원·수녀원 소식을 한곳에서 발견하고 연결하세요
+            </h1>
+            <p className="text-base text-muted-foreground sm:text-lg">
+              지도에서 기관을 찾고, 최신 활동을 확인하며, 후원과 봉사로 함께할 수 있는 공간입니다.
+            </p>
+          </div>
+          <div className="flex flex-wrap justify-center gap-3">
+            <Button asChild size="lg">
+              <Link href="/map">지도에서 찾기</Link>
+            </Button>
+            <Button asChild variant="secondary" size="lg">
+              <Link href="/contribute">참여 안내 보기</Link>
+            </Button>
+          </div>
+        </div>
+      </section>
+
+      <section className="space-y-6">
+        <div className="space-y-2">
+          <h2 className="text-xl font-semibold">허브에서 할 수 있는 것</h2>
+          <p className="text-sm text-muted-foreground">
+            수도회별 필터와 위치 정보, 소식 카드, 후원과 참여 정보까지 필요한 내용을 바로 만나보세요.
           </p>
-          <ThemeSwitcher />
-        </footer>
-      </div>
-    </main>
+        </div>
+        <div className="grid gap-4 sm:grid-cols-2 lg:grid-cols-3">
+          <Card className="transition hover:shadow-md">
+            <CardHeader className="pb-2 pt-4">
+              <CardTitle className="text-lg">지도에서 한눈에 탐색</CardTitle>
+            </CardHeader>
+            <CardContent className="space-y-3 text-sm text-muted-foreground">
+              <p>
+                수도회 유형과 지역으로 필터링하며 수도원·수녀원의 위치와 기본 정보를 살펴볼 수 있습니다.
+              </p>
+              <Button asChild size="sm" variant="outline">
+                <Link href="/map">찾기 페이지 이동</Link>
+              </Button>
+            </CardContent>
+          </Card>
+          <Card className="transition hover:shadow-md">
+            <CardHeader className="pb-2 pt-4">
+              <CardTitle className="text-lg">뉴스와 활동 모아보기</CardTitle>
+            </CardHeader>
+            <CardContent className="space-y-3 text-sm text-muted-foreground">
+              <p>
+                각 수도회의 소식, 봉사 후기, 행사 소식을 카드 형태로 정리해 빠르게 훑어볼 수 있습니다.
+              </p>
+              <Button asChild size="sm" variant="outline">
+                <Link href="/news">뉴스 페이지 이동</Link>
+              </Button>
+            </CardContent>
+          </Card>
+          <Card className="transition hover:shadow-md">
+            <CardHeader className="pb-2 pt-4">
+              <CardTitle className="text-lg">후원·구매·봉사로 동참</CardTitle>
+            </CardHeader>
+            <CardContent className="space-y-3 text-sm text-muted-foreground">
+              <p>
+                정기 후원 계좌, 수도원 제품 구매처, 봉사/피정 신청 정보를 확인하고 바로 참여할 수 있습니다.
+              </p>
+              <Button asChild size="sm" variant="outline">
+                <Link href="/contribute">기여 페이지 이동</Link>
+              </Button>
+            </CardContent>
+          </Card>
+        </div>
+      </section>
+
+      <section className="space-y-4">
+        <div className="space-y-2">
+          <h2 className="text-xl font-semibold">운영 원칙</h2>
+          <p className="text-sm text-muted-foreground">
+            수도자와 방문자 모두에게 도움이 되는 정보 아카이브를 지향합니다.
+          </p>
+        </div>
+        <div className="grid gap-4 sm:grid-cols-2">
+          <Card className="transition hover:shadow-md">
+            <CardHeader className="pb-2 pt-4">
+              <CardTitle className="text-base">정확한 정보 업데이트</CardTitle>
+            </CardHeader>
+            <CardContent className="space-y-2 text-sm text-muted-foreground">
+              <p>
+                Supabase와 연동된 데이터로 기관 소개, 연락처, 행사 정보를 주기적으로 검토하고 갱신합니다.
+              </p>
+              <Separator className="bg-border/70" />
+              <p>정보 수정이나 제보는 언제든지 이메일로 알려주세요.</p>
+            </CardContent>
+          </Card>
+          <Card className="transition hover:shadow-md">
+            <CardHeader className="pb-2 pt-4">
+              <CardTitle className="text-base">함께 만드는 공동체 지도</CardTitle>
+            </CardHeader>
+            <CardContent className="space-y-2 text-sm text-muted-foreground">
+              <p>
+                봉헌 생활을 소개하고 싶은 수도원·수녀원, 참여하고 싶은 방문자를 연결하는 열린 플랫폼을 지향합니다.
+              </p>
+              <Separator className="bg-border/70" />
+              <p>
+                운영팀과 협력해 자료를 정리하고 카드 뉴스 형태로 누구나 쉽게 공유할 수 있습니다.
+              </p>
+            </CardContent>
+          </Card>
+        </div>
+      </section>
+    </div>
   );
 }

--- a/my-app/components/contribution-card.tsx
+++ b/my-app/components/contribution-card.tsx
@@ -1,0 +1,64 @@
+import Link from "next/link";
+
+import { Button } from "@/components/ui/button";
+import {
+  Card,
+  CardContent,
+  CardHeader,
+  CardTitle,
+} from "@/components/ui/card";
+
+type DonationInfo = {
+  account?: string | null;
+  page_url?: string | null;
+};
+
+type ContributionCardProps = {
+  institution: {
+    id: string | number;
+    name: string;
+    slug: string;
+    donation?: DonationInfo | null;
+    summary?: string | null;
+  };
+};
+
+export default function ContributionCard({ institution }: ContributionCardProps) {
+  const donation = institution.donation ?? {};
+
+  return (
+    <Card className="h-full transition hover:shadow-md">
+      <CardHeader className="pb-2 pt-4">
+        <CardTitle className="text-base">{institution.name}</CardTitle>
+      </CardHeader>
+      <CardContent className="space-y-2 text-sm">
+        {institution.summary ? (
+          <p className="text-muted-foreground">{institution.summary}</p>
+        ) : null}
+        {donation.account ? (
+          <p>
+            계좌: <span className="font-semibold">{donation.account}</span>
+          </p>
+        ) : null}
+        {donation.page_url ? (
+          <a
+            href={donation.page_url}
+            target="_blank"
+            rel="noopener noreferrer"
+            className="underline-offset-4 hover:underline"
+            aria-label={`${institution.name} 후원 페이지 (새 창)`}
+          >
+            후원 페이지 바로가기
+          </a>
+        ) : null}
+        <div>
+          <Button asChild size="sm" variant="secondary">
+            <Link href={`/institutions/${institution.slug}`}>
+              기관 페이지
+            </Link>
+          </Button>
+        </div>
+      </CardContent>
+    </Card>
+  );
+}

--- a/my-app/components/filters/search-filters.tsx
+++ b/my-app/components/filters/search-filters.tsx
@@ -1,0 +1,94 @@
+"use client";
+
+import { useCallback, useEffect, useState } from "react";
+import { useRouter, useSearchParams } from "next/navigation";
+
+import { Input } from "@/components/ui/input";
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/ui/select";
+
+const typeOptions = [
+  { value: "", label: "전체" },
+  { value: "benedictine", label: "베네딕도회" },
+  { value: "carmelite", label: "카르멜회" },
+  { value: "franciscan", label: "프란치스코회" },
+];
+
+export default function SearchFilters() {
+  const router = useRouter();
+  const searchParams = useSearchParams();
+  const [keyword, setKeyword] = useState(() => searchParams.get("q") ?? "");
+
+  useEffect(() => {
+    setKeyword(searchParams.get("q") ?? "");
+  }, [searchParams]);
+
+  const typeValue = searchParams.get("type") ?? "";
+
+  const createUrl = useCallback(
+    (updates: Record<string, string | undefined>) => {
+      const params = new URLSearchParams(searchParams.toString());
+
+      Object.entries(updates).forEach(([key, value]) => {
+        if (!value) {
+          params.delete(key);
+        } else {
+          params.set(key, value);
+        }
+      });
+
+      const query = params.toString();
+      return query ? `/map?${query}` : "/map";
+    },
+    [searchParams],
+  );
+
+  const handleSubmit = useCallback(
+    (value: string) => {
+      const trimmed = value.trim();
+      router.push(createUrl({ q: trimmed || undefined }));
+    },
+    [router, createUrl],
+  );
+
+  return (
+    <div className="flex flex-wrap items-center gap-3">
+      <label className="w-full max-w-xs sm:max-w-sm">
+        <span className="sr-only">이름 또는 주소로 검색</span>
+        <Input
+          value={keyword}
+          onChange={(event) => setKeyword(event.target.value)}
+          onKeyDown={(event) => {
+            if (event.key === "Enter") {
+              event.preventDefault();
+              handleSubmit(event.currentTarget.value);
+            }
+          }}
+          placeholder="이름/주소로 검색"
+        />
+      </label>
+      <Select
+        value={typeValue}
+        onValueChange={(value) => {
+          router.push(createUrl({ type: value || undefined }));
+        }}
+      >
+        <SelectTrigger className="w-48 sm:w-56" aria-label="수도회 선택">
+          <SelectValue placeholder="수도회" />
+        </SelectTrigger>
+        <SelectContent>
+          {typeOptions.map((option) => (
+            <SelectItem key={option.value || "all"} value={option.value}>
+              {option.label}
+            </SelectItem>
+          ))}
+        </SelectContent>
+      </Select>
+    </div>
+  );
+}

--- a/my-app/components/filters/tag-badges.tsx
+++ b/my-app/components/filters/tag-badges.tsx
@@ -1,0 +1,23 @@
+import { Badge } from "@/components/ui/badge";
+import { cn } from "@/lib/utils";
+
+type TagBadgesProps = {
+  tags?: string[] | null;
+  className?: string;
+};
+
+export default function TagBadges({ tags, className }: TagBadgesProps) {
+  if (!tags || tags.length === 0) {
+    return null;
+  }
+
+  return (
+    <div className={cn("flex flex-wrap gap-1", className)}>
+      {tags.map((tag) => (
+        <Badge key={tag} variant="secondary">
+          {tag}
+        </Badge>
+      ))}
+    </div>
+  );
+}

--- a/my-app/components/footer.tsx
+++ b/my-app/components/footer.tsx
@@ -1,0 +1,50 @@
+import Link from "next/link";
+
+import { Separator } from "@/components/ui/separator";
+
+const footerLinks = [
+  { href: "/map", label: "찾기" },
+  { href: "/news", label: "뉴스" },
+  { href: "/contribute", label: "기여" },
+];
+
+export default function Footer() {
+  return (
+    <footer className="border-t bg-muted/20">
+      <div className="container mx-auto space-y-6 px-4 py-10">
+        <div className="flex flex-col gap-4 sm:flex-row sm:items-center sm:justify-between">
+          <div>
+            <p className="text-lg font-semibold">수도원·수녀원 허브</p>
+            <p className="text-sm text-muted-foreground">
+              전국의 수도원·수녀원 정보를 한눈에 모아 연결합니다.
+            </p>
+          </div>
+          <div className="flex flex-wrap gap-3 text-sm text-muted-foreground">
+            {footerLinks.map((item) => (
+              <Link
+                key={item.href}
+                href={item.href}
+                className="transition hover:text-foreground focus-visible:outline focus-visible:outline-2 focus-visible:outline-primary/60 focus-visible:outline-offset-4"
+              >
+                {item.label}
+              </Link>
+            ))}
+          </div>
+        </div>
+        <Separator />
+        <div className="flex flex-col gap-2 text-xs text-muted-foreground sm:flex-row sm:items-center sm:justify-between">
+          <p>© {new Date().getFullYear()} 수도원·수녀원 허브</p>
+          <p>
+            문의: {" "}
+            <a
+              href="mailto:contact@monastic-hub.kr"
+              className="underline-offset-4 hover:underline"
+            >
+              contact@monastic-hub.kr
+            </a>
+          </p>
+        </div>
+      </div>
+    </footer>
+  );
+}

--- a/my-app/components/header.tsx
+++ b/my-app/components/header.tsx
@@ -1,0 +1,53 @@
+"use client";
+
+import Link from "next/link";
+import { usePathname } from "next/navigation";
+
+import { Button } from "@/components/ui/button";
+
+const navigation = [
+  { href: "/map", label: "찾기" },
+  { href: "/news", label: "뉴스" },
+  { href: "/contribute", label: "기여" },
+];
+
+export default function Header() {
+  const pathname = usePathname();
+
+  return (
+    <header className="sticky top-0 z-50 border-b bg-background/80 backdrop-blur">
+      <div className="container mx-auto flex h-14 items-center justify-between px-4">
+        <Link
+          href="/"
+          className="font-semibold tracking-tight focus-visible:outline focus-visible:outline-2 focus-visible:outline-primary/60 focus-visible:outline-offset-4"
+        >
+          수도원·수녀원 허브
+        </Link>
+        <nav aria-label="주요 메뉴" className="flex gap-2">
+          {navigation.map((item) => {
+            const isActive =
+              pathname === item.href ||
+              pathname?.startsWith(`${item.href}/`) ||
+              (item.href === "/map" && pathname?.startsWith("/institutions"));
+            return (
+              <Button
+                key={item.href}
+                asChild
+                variant={isActive ? "default" : "ghost"}
+                size="sm"
+              >
+                <Link
+                  href={item.href}
+                  className="focus-visible:outline-none"
+                  aria-current={isActive ? "page" : undefined}
+                >
+                  {item.label}
+                </Link>
+              </Button>
+            );
+          })}
+        </nav>
+      </div>
+    </header>
+  );
+}

--- a/my-app/components/institution-hero.tsx
+++ b/my-app/components/institution-hero.tsx
@@ -1,0 +1,32 @@
+import TagBadges from "@/components/filters/tag-badges";
+import { Badge } from "@/components/ui/badge";
+
+interface InstitutionHeroProps {
+  name: string;
+  type?: string | null;
+  description?: string | null;
+  address?: string | null;
+  tags?: string[] | null;
+}
+
+export default function InstitutionHero({
+  name,
+  type,
+  description,
+  address,
+  tags,
+}: InstitutionHeroProps) {
+  return (
+    <section className="space-y-4 rounded-2xl border bg-card p-6 shadow-sm">
+      <div className="flex flex-wrap items-center gap-3">
+        <h1 className="text-2xl font-semibold tracking-tight">{name}</h1>
+        {type ? <Badge variant="secondary">{type}</Badge> : null}
+      </div>
+      {address ? <p className="text-sm text-muted-foreground">{address}</p> : null}
+      <TagBadges tags={tags} />
+      {description ? (
+        <p className="text-muted-foreground whitespace-pre-line">{description}</p>
+      ) : null}
+    </section>
+  );
+}

--- a/my-app/components/institution-list-item.tsx
+++ b/my-app/components/institution-list-item.tsx
@@ -1,0 +1,48 @@
+import Link from "next/link";
+
+import TagBadges from "@/components/filters/tag-badges";
+import { Badge } from "@/components/ui/badge";
+import {
+  Card,
+  CardContent,
+  CardHeader,
+  CardTitle,
+} from "@/components/ui/card";
+
+type InstitutionSummary = {
+  slug: string;
+  name: string;
+  type?: string | null;
+  address?: string | null;
+  tags?: string[] | null;
+};
+
+type InstitutionListItemProps = {
+  item: InstitutionSummary;
+};
+
+export default function InstitutionListItem({ item }: InstitutionListItemProps) {
+  return (
+    <Link
+      href={`/institutions/${item.slug}`}
+      className="block focus-visible:outline focus-visible:outline-2 focus-visible:outline-primary/60 focus-visible:outline-offset-4"
+    >
+      <Card className="transition hover:shadow-md">
+        <CardHeader className="space-y-2 pb-2 pt-4">
+          <CardTitle className="flex items-center gap-2 text-base">
+            {item.name}
+            {item.type ? <Badge variant="secondary">{item.type}</Badge> : null}
+          </CardTitle>
+          {item.address ? (
+            <p className="text-sm text-muted-foreground">{item.address}</p>
+          ) : null}
+        </CardHeader>
+        {item.tags && item.tags.length > 0 ? (
+          <CardContent className="pb-4 pt-0">
+            <TagBadges tags={item.tags} />
+          </CardContent>
+        ) : null}
+      </Card>
+    </Link>
+  );
+}

--- a/my-app/components/naver-map.tsx
+++ b/my-app/components/naver-map.tsx
@@ -1,0 +1,141 @@
+"use client";
+
+import { useEffect, useRef } from "react";
+import { useRouter } from "next/navigation";
+
+type NaverLatLng = unknown;
+type NaverMapInstance = unknown;
+type NaverMarkerInstance = unknown;
+
+type NaverMapOptions = {
+  center: NaverLatLng;
+  zoom: number;
+};
+
+type NaverMarkerOptions = {
+  position: NaverLatLng;
+  title?: string;
+  map: NaverMapInstance;
+};
+
+type NaverMaps = {
+  Map: new (element: HTMLElement, options: NaverMapOptions) => NaverMapInstance;
+  LatLng: new (lat: number, lng: number) => NaverLatLng;
+  Marker: new (options: NaverMarkerOptions) => NaverMarkerInstance;
+  Event: {
+    addListener: (
+      instance: NaverMarkerInstance,
+      eventName: string,
+      handler: () => void,
+    ) => void;
+  };
+};
+
+declare global {
+  interface Window {
+    naver?: {
+      maps?: NaverMaps;
+    };
+  }
+}
+
+type Marker = {
+  lat: number;
+  lng: number;
+  title?: string | null;
+  slug: string;
+};
+
+type NaverMapProps = {
+  center: {
+    lat: number;
+    lng: number;
+  };
+  markers: Marker[];
+  zoom?: number;
+};
+
+export default function NaverMap({ center, markers, zoom = 10 }: NaverMapProps) {
+  const mapId = useRef(`map_${Math.random().toString(36).slice(2)}`);
+  const router = useRouter();
+
+  useEffect(() => {
+    const scriptSrc = `https://oapi.map.naver.com/openapi/v3/maps.js?ncpClientId=${process.env.NEXT_PUBLIC_NAVER_MAP_CLIENT_ID ?? ""}`;
+    let scriptElement = document.querySelector<HTMLScriptElement>(
+      'script[src*="maps.js"]',
+    );
+
+    const initialize = () => {
+      const maps = window.naver?.maps;
+
+      if (!maps) {
+        return;
+      }
+
+      const container = document.getElementById(mapId.current) as
+        | HTMLElement
+        | null;
+
+      if (!container) {
+        return;
+      }
+
+      container.innerHTML = "";
+
+      const map = new maps.Map(container, {
+        center: new maps.LatLng(center.lat, center.lng),
+        zoom,
+      });
+
+      markers.forEach((marker) => {
+        if (
+          typeof marker.lat !== "number" ||
+          Number.isNaN(marker.lat) ||
+          typeof marker.lng !== "number" ||
+          Number.isNaN(marker.lng)
+        ) {
+          return;
+        }
+
+        const markerInstance = new maps.Marker({
+          position: new maps.LatLng(marker.lat, marker.lng),
+          title: marker.title ?? undefined,
+          map,
+        });
+
+        maps.Event.addListener(markerInstance, "click", () => {
+          router.push(`/institutions/${marker.slug}`);
+        });
+      });
+    };
+
+    const handleScriptLoad = () => {
+      initialize();
+    };
+
+    if (!scriptElement) {
+      scriptElement = document.createElement("script");
+      scriptElement.src = scriptSrc;
+      scriptElement.async = true;
+      document.head.appendChild(scriptElement);
+      scriptElement.addEventListener("load", handleScriptLoad);
+    } else if (window.naver?.maps) {
+      initialize();
+    } else {
+      scriptElement.addEventListener("load", handleScriptLoad);
+    }
+
+    return () => {
+      scriptElement?.removeEventListener("load", handleScriptLoad);
+    };
+  }, [center.lat, center.lng, markers, router, zoom]);
+
+  return (
+    <div
+      id={mapId.current}
+      className="h-[70vh] w-full rounded-2xl"
+      role="application"
+      aria-label="수도원·수녀원 위치 지도"
+    />
+  );
+}

--- a/my-app/components/news-card.tsx
+++ b/my-app/components/news-card.tsx
@@ -1,0 +1,69 @@
+import Image from "next/image";
+
+import TagBadges from "@/components/filters/tag-badges";
+import { Card, CardContent, CardFooter } from "@/components/ui/card";
+import { formatDate } from "@/lib/utils";
+
+type NewsItem = {
+  id: string | number;
+  title: string;
+  source_url?: string | null;
+  source_name?: string | null;
+  image_url?: string | null;
+  published_at?: string | null;
+  tags?: string[] | null;
+};
+
+type NewsCardProps = {
+  item: NewsItem;
+};
+
+export default function NewsCard({ item }: NewsCardProps) {
+  const publishedAt = formatDate(item.published_at, { dateStyle: "medium" });
+
+  const sourceLabel = item.source_name ?? (item.source_url ? "원문" : "");
+
+  const card = (
+    <Card className="h-full overflow-hidden transition hover:shadow-md">
+      {item.image_url ? (
+        <div className="relative h-40 w-full">
+          <Image
+            src={item.image_url}
+            alt={item.title}
+            fill
+            sizes="(min-width: 1280px) 250px, (min-width: 768px) 33vw, 100vw"
+            className="object-cover"
+          />
+        </div>
+      ) : null}
+      <CardContent className="space-y-2 p-4">
+        <p className="line-clamp-2 font-medium">{item.title}</p>
+        {publishedAt ? (
+          <p className="text-xs text-muted-foreground">{publishedAt}</p>
+        ) : null}
+        <TagBadges tags={item.tags} />
+      </CardContent>
+      {item.source_name || item.source_url ? (
+        <CardFooter className="p-4 pt-0 text-xs text-muted-foreground">
+          출처: {sourceLabel}
+        </CardFooter>
+      ) : null}
+    </Card>
+  );
+
+  if (item.source_url) {
+    return (
+      <a
+        href={item.source_url}
+        target="_blank"
+        rel="noopener noreferrer"
+        aria-label={`${item.title} 원문 기사 (새 창)`}
+        className="block focus-visible:outline focus-visible:outline-2 focus-visible:outline-primary/60 focus-visible:outline-offset-4"
+      >
+        {card}
+      </a>
+    );
+  }
+
+  return <article>{card}</article>;
+}

--- a/my-app/components/product-card.tsx
+++ b/my-app/components/product-card.tsx
@@ -1,0 +1,75 @@
+import Image from "next/image";
+
+import { Button } from "@/components/ui/button";
+import {
+  Card,
+  CardContent,
+  CardFooter,
+  CardHeader,
+  CardTitle,
+} from "@/components/ui/card";
+import { formatCurrency } from "@/lib/utils";
+
+type Product = {
+  id: string | number;
+  name: string;
+  image_url?: string | null;
+  price?: number | string | null;
+  category?: string | null;
+  unit?: string | null;
+  buy_url?: string | null;
+  description?: string | null;
+};
+
+type ProductCardProps = {
+  item: Product;
+};
+
+export default function ProductCard({ item }: ProductCardProps) {
+  const priceLabel = formatCurrency(item.price ?? undefined);
+  const meta = [item.category, item.unit].filter(Boolean).join(" · ");
+
+  return (
+    <Card className="h-full overflow-hidden transition hover:shadow-md">
+      <CardHeader className="pb-2 pt-4">
+        <CardTitle className="text-base">{item.name}</CardTitle>
+      </CardHeader>
+      <CardContent className="space-y-3">
+        {item.image_url ? (
+          <div className="relative h-40 w-full overflow-hidden rounded-lg">
+            <Image
+              src={item.image_url}
+              alt={item.name}
+              fill
+              sizes="(min-width: 1280px) 250px, (min-width: 768px) 33vw, 100vw"
+              className="object-cover"
+            />
+          </div>
+        ) : null}
+        {meta ? <p className="text-sm text-muted-foreground">{meta}</p> : null}
+        {priceLabel ? (
+          <p className="text-base font-semibold text-foreground">{priceLabel}</p>
+        ) : null}
+        {item.description ? (
+          <p className="text-sm text-muted-foreground line-clamp-2">
+            {item.description}
+          </p>
+        ) : null}
+      </CardContent>
+      {item.buy_url ? (
+        <CardFooter className="pt-0">
+          <Button asChild size="sm">
+            <a
+              href={item.buy_url}
+              target="_blank"
+              rel="noopener noreferrer"
+              aria-label={`${item.name} 구매 페이지 (새 창)`}
+            >
+              구매하기
+            </a>
+          </Button>
+        </CardFooter>
+      ) : null}
+    </Card>
+  );
+}

--- a/my-app/components/ui/card.tsx
+++ b/my-app/components/ui/card.tsx
@@ -9,7 +9,7 @@ const Card = React.forwardRef<
   <div
     ref={ref}
     className={cn(
-      "rounded-xl border bg-card text-card-foreground shadow",
+      "rounded-2xl border bg-card text-card-foreground shadow-sm",
       className,
     )}
     {...props}

--- a/my-app/components/ui/select.tsx
+++ b/my-app/components/ui/select.tsx
@@ -1,0 +1,285 @@
+"use client";
+
+import * as React from "react";
+
+import { cn } from "@/lib/utils";
+
+type SelectContextValue = {
+  value: string;
+  open: boolean;
+  setOpen: (open: boolean) => void;
+  onSelect: (value: string, label: string) => void;
+  selectedLabel?: string;
+  setSelectedLabel: (label: string | undefined) => void;
+  triggerRef: React.RefObject<HTMLButtonElement>;
+  contentRef: React.RefObject<HTMLDivElement>;
+  disabled: boolean;
+};
+
+const SelectContext = React.createContext<SelectContextValue | null>(null);
+
+function useSelectContext(component: string) {
+  const context = React.useContext(SelectContext);
+
+  if (!context) {
+    throw new Error(`${component}는 Select 컴포넌트 내부에서만 사용할 수 있습니다.`);
+  }
+
+  return context;
+}
+
+type SelectProps = {
+  value?: string;
+  defaultValue?: string;
+  onValueChange?: (value: string) => void;
+  disabled?: boolean;
+  className?: string;
+  children: React.ReactNode;
+};
+
+export function Select({
+  value,
+  defaultValue,
+  onValueChange,
+  disabled = false,
+  className,
+  children,
+}: SelectProps) {
+  const [internalValue, setInternalValue] = React.useState(defaultValue ?? "");
+  const [selectedLabel, setSelectedLabel] = React.useState<string | undefined>();
+  const [open, setOpen] = React.useState(false);
+  const triggerRef = React.useRef<HTMLButtonElement>(null);
+  const contentRef = React.useRef<HTMLDivElement>(null);
+
+  const actualValue = value ?? internalValue;
+
+  const handleSelect = React.useCallback(
+    (nextValue: string, label: string) => {
+      if (value === undefined) {
+        setInternalValue(nextValue);
+      }
+      setSelectedLabel(label || undefined);
+      onValueChange?.(nextValue);
+      setOpen(false);
+    },
+    [value, onValueChange],
+  );
+
+  const contextValue = React.useMemo<SelectContextValue>(
+    () => ({
+      value: actualValue ?? "",
+      open,
+      setOpen,
+      onSelect: handleSelect,
+      selectedLabel,
+      setSelectedLabel,
+      triggerRef,
+      contentRef,
+      disabled,
+    }),
+    [actualValue, open, handleSelect, selectedLabel, disabled],
+  );
+
+  React.useEffect(() => {
+    if (!open) {
+      return undefined;
+    }
+
+    const handleClickOutside = (event: MouseEvent) => {
+      const target = event.target as Node;
+
+      if (
+        triggerRef.current?.contains(target) ||
+        contentRef.current?.contains(target)
+      ) {
+        return;
+      }
+
+      setOpen(false);
+    };
+
+    document.addEventListener("mousedown", handleClickOutside);
+    return () => document.removeEventListener("mousedown", handleClickOutside);
+  }, [open]);
+
+  return (
+    <SelectContext.Provider value={contextValue}>
+      <div className={cn("relative inline-block text-left", className)}>
+        {children}
+      </div>
+    </SelectContext.Provider>
+  );
+}
+
+type SelectTriggerProps = React.ButtonHTMLAttributes<HTMLButtonElement>;
+
+export const SelectTrigger = React.forwardRef<HTMLButtonElement, SelectTriggerProps>(
+  ({ className, children, ...props }, ref) => {
+    const context = useSelectContext("SelectTrigger");
+
+    const handleRef = React.useCallback(
+      (node: HTMLButtonElement | null) => {
+        context.triggerRef.current = node;
+
+        if (typeof ref === "function") {
+          ref(node);
+        } else if (ref) {
+          (ref as React.MutableRefObject<HTMLButtonElement | null>).current = node;
+        }
+      },
+      [context, ref],
+    );
+
+    return (
+      <button
+        type="button"
+        ref={handleRef}
+        className={cn(
+          "flex w-full items-center justify-between gap-2 rounded-md border border-input bg-background px-3 py-2 text-sm shadow-sm transition hover:bg-accent hover:text-accent-foreground focus-visible:outline focus-visible:outline-2 focus-visible:outline-primary/60 focus-visible:outline-offset-2 disabled:cursor-not-allowed disabled:opacity-50",
+          className,
+        )}
+        aria-haspopup="listbox"
+        aria-expanded={context.open}
+        aria-disabled={context.disabled}
+        onClick={() => {
+          if (context.disabled) {
+            return;
+          }
+
+          context.setOpen(!context.open);
+        }}
+        {...props}
+      >
+        <span className="flex-1 truncate text-left">
+          {children ?? <SelectValue />}
+        </span>
+        <svg
+          aria-hidden="true"
+          focusable="false"
+          className="size-4 shrink-0 opacity-60"
+          viewBox="0 0 20 20"
+        >
+          <path
+            fill="currentColor"
+            d="M5.23 7.21a.75.75 0 0 1 1.06.02L10 11.17l3.71-3.94a.75.75 0 0 1 1.08 1.04l-4.25 4.5a.75.75 0 0 1-1.08 0l-4.25-4.5a.75.75 0 0 1 .02-1.06Z"
+          />
+        </svg>
+      </button>
+    );
+  },
+);
+SelectTrigger.displayName = "SelectTrigger";
+
+type SelectContentProps = React.HTMLAttributes<HTMLDivElement>;
+
+export const SelectContent = React.forwardRef<HTMLDivElement, SelectContentProps>(
+  ({ className, children, ...props }, ref) => {
+    const context = useSelectContext("SelectContent");
+
+    const handleRef = React.useCallback(
+      (node: HTMLDivElement | null) => {
+        context.contentRef.current = node;
+
+        if (typeof ref === "function") {
+          ref(node);
+        } else if (ref) {
+          (ref as React.MutableRefObject<HTMLDivElement | null>).current = node;
+        }
+      },
+      [context, ref],
+    );
+
+    if (!context.open) {
+      return null;
+    }
+
+    const width = context.triggerRef.current?.offsetWidth;
+
+    return (
+      <div
+        ref={handleRef}
+        className={cn(
+          "absolute z-50 mt-2 max-h-60 min-w-[8rem] overflow-auto rounded-md border bg-popover p-1 text-popover-foreground shadow-lg focus:outline-none",
+          className,
+        )}
+        style={{ minWidth: width }}
+        role="listbox"
+        tabIndex={-1}
+        onKeyDown={(event) => {
+          if (event.key === "Escape") {
+            context.setOpen(false);
+          }
+        }}
+        {...props}
+      >
+        {children}
+      </div>
+    );
+  },
+);
+SelectContent.displayName = "SelectContent";
+
+type SelectItemProps = React.ButtonHTMLAttributes<HTMLButtonElement> & {
+  value: string;
+  textValue?: string;
+};
+
+export const SelectItem = React.forwardRef<HTMLButtonElement, SelectItemProps>(
+  ({ className, children, value, textValue, ...props }, ref) => {
+    const context = useSelectContext("SelectItem");
+
+    const label =
+      textValue ??
+      (typeof children === "string" ? children : value ?? textValue ?? "");
+
+    const isSelected = context.value === value;
+
+    React.useEffect(() => {
+      if (isSelected) {
+        context.setSelectedLabel(label || undefined);
+      }
+    }, [isSelected, label, context]);
+
+    return (
+      <button
+        ref={ref}
+        type="button"
+        role="option"
+        data-state={isSelected ? "checked" : "unchecked"}
+        aria-selected={isSelected}
+        className={cn(
+          "relative flex w-full cursor-pointer select-none items-center gap-2 rounded-md px-3 py-2 text-sm transition hover:bg-accent hover:text-accent-foreground focus-visible:outline focus-visible:outline-2 focus-visible:outline-primary/60",
+          isSelected && "bg-accent text-accent-foreground",
+          className,
+        )}
+        onClick={() => context.onSelect(value, label ?? value)}
+        {...props}
+      >
+        {children}
+      </button>
+    );
+  },
+);
+SelectItem.displayName = "SelectItem";
+
+type SelectValueProps = {
+  placeholder?: string;
+  className?: string;
+};
+
+export function SelectValue({ placeholder, className }: SelectValueProps) {
+  const context = useSelectContext("SelectValue");
+
+  const displayValue =
+    context.selectedLabel && context.selectedLabel.length > 0
+      ? context.selectedLabel
+      : context.value
+      ? context.value
+      : undefined;
+
+  return (
+    <span className={cn("block truncate", className)}>
+      {displayValue ?? placeholder}
+    </span>
+  );
+}

--- a/my-app/components/ui/separator.tsx
+++ b/my-app/components/ui/separator.tsx
@@ -1,0 +1,32 @@
+import * as React from "react";
+
+import { cn } from "@/lib/utils";
+
+type SeparatorProps = React.HTMLAttributes<HTMLDivElement> & {
+  orientation?: "horizontal" | "vertical";
+  decorative?: boolean;
+};
+
+const Separator = React.forwardRef<HTMLDivElement, SeparatorProps>(
+  ({ className, orientation = "horizontal", decorative = true, ...props }, ref) => {
+    const isVertical = orientation === "vertical";
+
+    return (
+      <div
+        ref={ref}
+        role="separator"
+        aria-orientation={orientation}
+        aria-hidden={decorative ? "true" : undefined}
+        className={cn(
+          "bg-border",
+          isVertical ? "h-full w-px" : "h-px w-full",
+          className,
+        )}
+        {...props}
+      />
+    );
+  },
+);
+Separator.displayName = "Separator";
+
+export { Separator };

--- a/my-app/components/ui/skeleton.tsx
+++ b/my-app/components/ui/skeleton.tsx
@@ -1,0 +1,14 @@
+import type React from "react";
+
+import { cn } from "@/lib/utils";
+
+type SkeletonProps = React.HTMLAttributes<HTMLDivElement>;
+
+export function Skeleton({ className, ...props }: SkeletonProps) {
+  return (
+    <div
+      className={cn("animate-pulse rounded-md bg-muted", className)}
+      {...props}
+    />
+  );
+}

--- a/my-app/components/ui/tabs.tsx
+++ b/my-app/components/ui/tabs.tsx
@@ -1,0 +1,162 @@
+"use client";
+
+import * as React from "react";
+
+import { cn } from "@/lib/utils";
+
+type TabsContextValue = {
+  value: string;
+  setValue: (value: string) => void;
+  idPrefix: string;
+};
+
+const TabsContext = React.createContext<TabsContextValue | null>(null);
+
+function useTabsContext(component: string) {
+  const context = React.useContext(TabsContext);
+
+  if (!context) {
+    throw new Error(`${component}는 Tabs 컴포넌트 내부에서만 사용할 수 있습니다.`);
+  }
+
+  return context;
+}
+
+type TabsProps = {
+  value?: string;
+  defaultValue?: string;
+  onValueChange?: (value: string) => void;
+  className?: string;
+  children: React.ReactNode;
+};
+
+export function Tabs({
+  value,
+  defaultValue,
+  onValueChange,
+  className,
+  children,
+}: TabsProps) {
+  const [internalValue, setInternalValue] = React.useState<string | undefined>(
+    defaultValue,
+  );
+  const generatedId = React.useId();
+
+  React.useEffect(() => {
+    if (value === undefined) {
+      setInternalValue(defaultValue);
+    }
+  }, [defaultValue, value]);
+
+  const activeValue = value ?? internalValue ?? "";
+
+  const handleValueChange = React.useCallback(
+    (nextValue: string) => {
+      if (value === undefined) {
+        setInternalValue(nextValue);
+      }
+      onValueChange?.(nextValue);
+    },
+    [value, onValueChange],
+  );
+
+  const contextValue = React.useMemo<TabsContextValue>(
+    () => ({
+      value: activeValue,
+      setValue: handleValueChange,
+      idPrefix: generatedId,
+    }),
+    [activeValue, handleValueChange, generatedId],
+  );
+
+  return (
+    <TabsContext.Provider value={contextValue}>
+      <div className={cn("flex flex-col gap-4", className)}>{children}</div>
+    </TabsContext.Provider>
+  );
+}
+
+type TabsListProps = React.HTMLAttributes<HTMLDivElement>;
+
+export const TabsList = React.forwardRef<HTMLDivElement, TabsListProps>(
+  ({ className, ...props }, ref) => (
+    <div
+      ref={ref}
+      role="tablist"
+      className={cn(
+        "inline-flex h-10 items-center justify-center rounded-full bg-muted p-1 text-muted-foreground",
+        className,
+      )}
+      {...props}
+    />
+  ),
+);
+TabsList.displayName = "TabsList";
+
+type TabsTriggerProps = React.ButtonHTMLAttributes<HTMLButtonElement> & {
+  value: string;
+};
+
+export const TabsTrigger = React.forwardRef<HTMLButtonElement, TabsTriggerProps>(
+  ({ className, value: itemValue, children, ...props }, ref) => {
+    const context = useTabsContext("TabsTrigger");
+    const isActive = context.value === itemValue;
+    const triggerId = `${context.idPrefix}-trigger-${itemValue}`;
+    const panelId = `${context.idPrefix}-content-${itemValue}`;
+
+    return (
+      <button
+        ref={ref}
+        type="button"
+        role="tab"
+        id={triggerId}
+        aria-selected={isActive}
+        aria-controls={panelId}
+        data-state={isActive ? "active" : "inactive"}
+        className={cn(
+          "inline-flex items-center justify-center whitespace-nowrap rounded-full px-3 py-1.5 text-sm font-medium transition focus-visible:outline focus-visible:outline-2 focus-visible:outline-primary/60 data-[state=active]:bg-background data-[state=active]:text-foreground",
+          isActive ? "shadow-sm" : "hover:text-foreground",
+          className,
+        )}
+        onClick={(event) => {
+          props.onClick?.(event);
+          if (!isActive) {
+            context.setValue(itemValue);
+          }
+        }}
+        {...props}
+      >
+        {children}
+      </button>
+    );
+  },
+);
+TabsTrigger.displayName = "TabsTrigger";
+
+type TabsContentProps = React.HTMLAttributes<HTMLDivElement> & {
+  value: string;
+};
+
+export const TabsContent = React.forwardRef<HTMLDivElement, TabsContentProps>(
+  ({ className, value: itemValue, children, ...props }, ref) => {
+    const context = useTabsContext("TabsContent");
+    const isActive = context.value === itemValue;
+    const triggerId = `${context.idPrefix}-trigger-${itemValue}`;
+    const panelId = `${context.idPrefix}-content-${itemValue}`;
+
+    return (
+      <div
+        ref={ref}
+        role="tabpanel"
+        id={panelId}
+        aria-labelledby={triggerId}
+        hidden={!isActive}
+        className={cn("focus-visible:outline-none", className)}
+        {...props}
+      >
+        {isActive ? children : null}
+      </div>
+    );
+  },
+);
+TabsContent.displayName = "TabsContent";

--- a/my-app/lib/supabase-server.ts
+++ b/my-app/lib/supabase-server.ts
@@ -1,0 +1,21 @@
+import "server-only";
+
+import { createClient } from "@supabase/supabase-js";
+
+const supabaseUrl = process.env.SUPABASE_URL ?? process.env.NEXT_PUBLIC_SUPABASE_URL;
+const supabaseAnonKey =
+  process.env.SUPABASE_ANON_KEY ??
+  process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY ??
+  process.env.NEXT_PUBLIC_SUPABASE_PUBLISHABLE_OR_ANON_KEY;
+
+if (!supabaseUrl || !supabaseAnonKey) {
+  throw new Error("Supabase 환경 변수가 설정되지 않았습니다.");
+}
+
+export function sb() {
+  return createClient(supabaseUrl, supabaseAnonKey, {
+    auth: {
+      persistSession: false,
+    },
+  });
+}

--- a/my-app/lib/utils.ts
+++ b/my-app/lib/utils.ts
@@ -5,6 +5,56 @@ export function cn(...inputs: ClassValue[]) {
   return twMerge(clsx(inputs));
 }
 
+export function formatCurrency(value: number | string | null | undefined) {
+  if (value === null || value === undefined) {
+    return "";
+  }
+
+  const numericValue = typeof value === "number" ? value : Number(value);
+
+  if (Number.isNaN(numericValue)) {
+    return "";
+  }
+
+  return new Intl.NumberFormat("ko-KR", {
+    style: "currency",
+    currency: "KRW",
+    maximumFractionDigits: 0,
+  }).format(numericValue);
+}
+
+export function formatDate(
+  value: string | number | Date | null | undefined,
+  options?: Intl.DateTimeFormatOptions,
+) {
+  if (!value) {
+    return "";
+  }
+
+  const date = value instanceof Date ? value : new Date(value);
+
+  if (Number.isNaN(date.getTime())) {
+    return "";
+  }
+
+  return new Intl.DateTimeFormat("ko-KR", options ?? { dateStyle: "medium" }).format(
+    date,
+  );
+}
+
+export function formatDateTime(
+  value: string | number | Date | null | undefined,
+  options?: Intl.DateTimeFormatOptions,
+) {
+  return formatDate(
+    value,
+    options ?? {
+      dateStyle: "medium",
+      timeStyle: "short",
+    },
+  );
+}
+
 // This check can be removed, it is just for tutorial purposes
 export const hasEnvVars =
   process.env.NEXT_PUBLIC_SUPABASE_URL &&

--- a/my-app/next.config.ts
+++ b/my-app/next.config.ts
@@ -1,7 +1,18 @@
 import type { NextConfig } from "next";
 
 const nextConfig: NextConfig = {
-  /* config options here */
+  images: {
+    remotePatterns: [
+      {
+        protocol: "https",
+        hostname: "**",
+      },
+      {
+        protocol: "http",
+        hostname: "**",
+      },
+    ],
+  },
 };
 
 export default nextConfig;

--- a/my-app/tailwind.config.ts
+++ b/my-app/tailwind.config.ts
@@ -10,6 +10,18 @@ export default {
   ],
   theme: {
     extend: {
+      container: {
+        center: true,
+        padding: {
+          DEFAULT: "1rem",
+          sm: "1.5rem",
+          lg: "2rem",
+          xl: "2.5rem",
+        },
+        screens: {
+          "2xl": "1200px",
+        },
+      },
       colors: {
         background: "hsl(var(--background))",
         foreground: "hsl(var(--foreground))",

--- a/my-app/tsconfig.json
+++ b/my-app/tsconfig.json
@@ -1,7 +1,11 @@
 {
   "compilerOptions": {
     "target": "ES2017",
-    "lib": ["dom", "dom.iterable", "esnext"],
+    "lib": [
+      "dom",
+      "dom.iterable",
+      "esnext"
+    ],
     "allowJs": true,
     "skipLibCheck": true,
     "strict": true,
@@ -12,7 +16,7 @@
     "moduleResolution": "bundler",
     "resolveJsonModule": true,
     "isolatedModules": true,
-    "jsx": "react-jsx",
+    "jsx": "preserve",
     "incremental": true,
     "plugins": [
       {
@@ -20,9 +24,18 @@
       }
     ],
     "paths": {
-      "@/*": ["./*"]
+      "@/*": [
+        "./*"
+      ]
     }
   },
-  "include": ["next-env.d.ts", "**/*.ts", "**/*.tsx", ".next/types/**/*.ts"],
-  "exclude": ["node_modules"]
+  "include": [
+    "next-env.d.ts",
+    "**/*.ts",
+    "**/*.tsx",
+    ".next/types/**/*.ts"
+  ],
+  "exclude": [
+    "node_modules"
+  ]
 }


### PR DESCRIPTION
## Summary
- replace the global layout with the 수도원·수녀원 허브 header, footer, and a new landing experience
- add map, institution, news, and contribute pages that load Supabase content and integrate the Naver map interaction
- implement supporting UI pieces (filters, cards, shadcn-style select/tabs utilities) to match the requested design system

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68ce2508a3b0832aa959392a0669c55f